### PR TITLE
Fix for attached scripts that are invalid

### DIFF
--- a/Editor/Core/HierarchyRenderer.cs
+++ b/Editor/Core/HierarchyRenderer.cs
@@ -359,6 +359,9 @@ namespace MyHierarchy
                     break;
 
                 Type componentType = components[i].GetType();
+                
+                if (componentType == null) 
+                    continue;
 
                 // Do not render transform or Rect Transform icons since we they are not that important to know
                 if (componentType == typeof(Transform) || componentType == typeof(RectTransform))

--- a/Editor/Core/HierarchyRenderer.cs
+++ b/Editor/Core/HierarchyRenderer.cs
@@ -358,6 +358,9 @@ namespace MyHierarchy
                 if (components.Length <= 1) // if there is one component in the object just don't render any icon we know it's either transform or rect transform
                     break;
 
+                if (components[i] == null)
+                    continue;
+
                 Type componentType = components[i].GetType();
                 
                 if (componentType == null) 


### PR DESCRIPTION
This is a small fix for when the hierarchy becomes unresponsive when there are scripts that are missing or invalid.